### PR TITLE
feat: end to end rough functionality is now supported. add to library…

### DIFF
--- a/back/src/handlers/auth.tsx
+++ b/back/src/handlers/auth.tsx
@@ -3,7 +3,7 @@ import {clientId, client_secret} from "../../private/keys";
 import {Buffer} from 'buffer'
 
 import {Request, Response} from 'express'
-const frontEndBaseURL = 'http://localhost:8000/results'
+const frontEndBaseURL = 'http://localhost:8000/'
 
 // checkout https://developer.spotify.com/documentation/web-api/tutorials/code-flow 
 // for workflow 

--- a/back/src/handlers/getGenres.tsx
+++ b/back/src/handlers/getGenres.tsx
@@ -1,0 +1,36 @@
+import {Request, Response} from 'express'
+import { AuthKey } from "../handlerUtilities/authObj"
+import { errorMap, successMap } from "../server"
+
+export async function getGenres(req: Request, res: Response, token : AuthKey) {
+    const url = `https://api.spotify.com/v1/recommendations/available-genre-seeds`
+    
+    const headers = {
+        'content-type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Bearer ' + token.getAuthToken()
+    }
+
+    let queryResponse = await fetch(url, {
+        method: 'GET',
+        headers : headers
+    }).then(res => res.json())
+
+    if ("genres" in queryResponse) {
+        let clientResponse : successMap = {
+            status: "success",
+            data: queryResponse
+        }
+        res.send(clientResponse)
+        return 
+    }  else {
+        let clientResponse : errorMap = {
+            status: "error",
+            error_type: "bad_authentication",
+            error_message: "was not able to retrieve available genres"
+        }
+        res.send(clientResponse)
+        return
+    }
+
+}
+

--- a/back/src/handlers/getRecommendations.tsx
+++ b/back/src/handlers/getRecommendations.tsx
@@ -22,7 +22,7 @@ export async function getRecommendationsHandle(req: Request, res: Response, toke
         if (req.query.seed_artists != undefined) {
             url += `seed_artists=${req.query.seed_artists}&`
         }
-        if (req.query.seed_artists != undefined) {
+        if (req.query.seed_genres != undefined) {
             url += `seed_genres=${req.query.seed_genres}&`
         }
         if (req.query.seed_tracks != undefined) {

--- a/back/src/handlers/search.tsx
+++ b/back/src/handlers/search.tsx
@@ -5,7 +5,7 @@ import { errorMap, successMap } from "../server"
 
 
 
-export async function searchArtistHandle(req: Request, res: Response, token: AuthKey) {
+export async function searchHandle(req: Request, res: Response, token: AuthKey) {
     console.log(req.query.artists)
     console.log(req.query.tracks)
     

--- a/back/src/server.tsx
+++ b/back/src/server.tsx
@@ -4,10 +4,11 @@ import cors from 'cors';
 import { test } from './handlers/test';
 import {AuthKey} from './handlerUtilities/authObj'
 import { initialAuth } from './handlers/initialAuth';
-import { searchArtistHandle } from './handlers/searchArtist';
+import { searchHandle } from './handlers/search';
 import { getRecommendationsHandle } from './handlers/getRecommendations';
 import { generatePlaylistHandle } from './handlers/generatePlaylist';
 import { search_uid } from './handlers/UIDSearch';
+import { getGenres } from './handlers/getGenres';
 
 
 
@@ -54,7 +55,7 @@ app.get('/fetch_auth', (req: Request, res: Response) => fetchToken(req, res))
 // app.get('/test', (req: Request, res: Response) => test(req, res, userAuthToken))
 
 // to search an artist and get their uri -- needs the client Auth Token
-app.get('/search',cors(), (req: Request, res: Response) => searchArtistHandle(req, res, clientAuthToken) )
+app.get('/search',cors(), (req: Request, res: Response) => searchHandle(req, res, clientAuthToken) )
 
 // to search for a set of recommendations
 app.get('/get_recommendations', cors(), (req: Request, res: Response) => getRecommendationsHandle(req, res, clientAuthToken) )
@@ -64,6 +65,9 @@ app.get('/generate_playlist', cors(), (req: Request, res: Response) => generateP
 
 // searches for an artist or track based on the id
 app.get('/search_id', cors(), (req: Request, res: Response) => search_uid(req, res, clientAuthToken))
+
+// retrives all available genres
+app.get('/get_genres', cors(), (req: Request, res: Response) => getGenres(req, res, clientAuthToken))
 
 app.listen(port, () => {
     console.log('Server running on http://localhost:' + port)

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -8,6 +8,7 @@ import { SeedsPage } from './pages/SeedsPage';
 import { SelectFeatsPage } from './pages/SelectFeatsPage';
 import { SelectSeedsPage } from './pages/SelectSeedsPage';
 import { DurationPage } from './pages/DurationsPage';
+import { trackResponse } from './components/TrackResultCard';
 
 function App() {
 
@@ -18,6 +19,13 @@ function App() {
   const [featsMap] = useState<Map<string, number>>(new Map<string, number>())
   const [seedsMap] = useState<Map<string, string[]>>(new Map<string, string[]>())
 
+  // props used for the results object:
+  const [returnedTracks, setReturnedTracks] = useState<trackResponse[]>([])
+  const [totalTime, setTotalTime] = useState<number>(0);
+  const [noSongs, setNoSongs] = useState<number>(0);
+
+  const [authToken, setAuthToken] = useState<string>('')
+
 	return (
     <Router basename="">
       <Routes>
@@ -27,7 +35,10 @@ function App() {
         {/* make a duration page, pass in the feats map*/}
 
         <Route path="/duration" element = 
-          {<DurationPage featsMap={featsMap} seedMap = {seedsMap}></DurationPage>}
+          {<DurationPage featsMap={featsMap} seedMap = {seedsMap}
+          returnedTracks = {returnedTracks} setReturnedTracks = {setReturnedTracks}
+          totalTime = {totalTime} setTotalTime = {setTotalTime}
+          noSongs = {noSongs} setNoSongs = {setNoSongs}></DurationPage>}
         /> 
 
         <Route path="/select-seeds" element = 
@@ -41,8 +52,12 @@ function App() {
         /> 
         <Route path="/feats" element = {<FeatsPage featNames = {featNames} setFeatNames = {setFeatNames}></FeatsPage>}/> 
         <Route path="/seeds" element = {<SeedsPage seedNames = {seedNames} setSeedNames= {setSeedNames}></SeedsPage>}/> 
-        <Route path="/results" element = {<ResultsPage></ResultsPage>}/> 
-        <Route path="/" element = {<HomePage></HomePage>}/> 
+        <Route path="/results" element = {<ResultsPage
+                  authToken={authToken}
+                  returnedTracks = {returnedTracks} setReturnedTracks = {setReturnedTracks}
+                  totalTime = {totalTime} setTotalTime = {setTotalTime}
+                  noSongs = {noSongs} setNoSongs = {setNoSongs}></ResultsPage>}/> 
+        <Route path="/" element = {<HomePage authToken={authToken} setAuthToken={setAuthToken}></HomePage>}/> 
       </Routes>
     </Router>
           );

--- a/front/src/components/GenreResultCard.tsx
+++ b/front/src/components/GenreResultCard.tsx
@@ -1,0 +1,50 @@
+import { genreResponse } from "./SearchBox";
+
+interface prop {
+    selectedSeeds: string[][], 
+    setSelectedSeeds: React.Dispatch<React.SetStateAction<string[][]>>,
+
+    seedMap: Map<String, String[]>,
+
+    resultInfo: genreResponse;
+}
+
+
+export function GenreResultCard(props: prop) {
+
+    function addTrack() {
+        if (!(props.selectedSeeds.map(x => x[0]).includes(props.resultInfo.data))) {
+
+            // selectedSeeds keeps track of the id, category, name and image
+            // TODO: replace the fourth argument with a valid photo path.
+            props.setSelectedSeeds([... props.selectedSeeds, [props.resultInfo.data, "genres", props.resultInfo.data, ""]])
+
+            //updating seeds map
+            let existing: String[] | undefined = props.seedMap.get("genres")!;
+            if (existing !== undefined) {
+                props.seedMap.set("genres", [...existing, props.resultInfo.data]);
+            } else {
+                props.seedMap.set("genres", [props.resultInfo.data]);
+            }
+
+        } else {
+            props.setSelectedSeeds(props.selectedSeeds.filter(obj => !(obj.includes(props.resultInfo.data))))
+            let existing = props.seedMap.get("genres");
+            if ( existing !== undefined) {
+                props.seedMap.set("genres", existing.filter(obj => obj!= props.resultInfo.data))
+            }
+        }
+    }
+
+    return (
+        <div className = {"track-result-card"} id = {"genres"+props.resultInfo.data} onClick = {addTrack}>
+            <div style = {{display: "flex", alignItems:"center"}}>
+                <img src = {""} style = {{width:"50px", height:"50px", marginRight: "1rem"}}/>
+                <div>
+                    <h4>{props.resultInfo.data}</h4>
+                </div>
+            </div>
+        </div>
+        
+    )
+}

--- a/front/src/components/RecommendedTrackCard.tsx
+++ b/front/src/components/RecommendedTrackCard.tsx
@@ -1,70 +1,20 @@
-import { useEffect} from "react";
+import { useEffect } from "react";
+import { trackResponse } from "./TrackResultCard";
 
 interface prop {
-    selectedSeeds: string[][], 
-    setSelectedSeeds: React.Dispatch<React.SetStateAction<string[][]>>,
 
-    seedMap: Map<String, String[]>,
 
     resultInfo: trackResponse;
 }
-
-/**
- * All the vital information pertaining to a given track.
- */
-export interface trackResponse {
-    album: {
-        images: {
-            url: string
-            height: number
-            width: number
-        }[]
-    }
-    artists: {
-        name: string
-    }[]
-    id: string
-    name: string
-    type: string
-    duration_ms: number
-    uri:string
-}
-
 /**
  * This component defines the drop down search results from searching for a track
  * @param props of type prop is defined by the interface above.
  * @returns a component containing information about a given track.
  */
-export function TrackResultCard(props: prop) {
+export function RecommendedTrackCard(props: prop) {
 
     useEffect(() => {
     } ,[props.resultInfo])
-
-    /**
-     * This function adds a track to the seedsMap in addition to the seeds list.
-     */
-    function addTrack() {
-        if (!(props.selectedSeeds.map(x => x[0]).includes(props.resultInfo.id))) {
-
-            // selectedSeeds keeps track of the id, category, name and image
-            props.setSelectedSeeds([... props.selectedSeeds, [props.resultInfo.id, "tracks", props.resultInfo.name, returnImages()]])
-
-            //updating seeds map
-            let existing: String[] | undefined = props.seedMap.get("tracks")!;
-            if (existing !== undefined) {
-                props.seedMap.set("tracks", [...existing, props.resultInfo.id]);
-            } else {
-                props.seedMap.set("tracks", [props.resultInfo.id]);
-            }
-
-        } else {
-            props.setSelectedSeeds(props.selectedSeeds.filter(obj => !(obj.includes(props.resultInfo.id))))
-            let existing = props.seedMap.get("tracks");
-            if ( existing !== undefined) {
-                props.seedMap.set("tracks", existing.filter(obj => obj!= props.resultInfo.id))
-            }
-        }
-    }
 
     /**
      * Extracts the artis information from a given track. must loop through all artists
@@ -123,7 +73,7 @@ export function TrackResultCard(props: prop) {
         }
     }
     return (
-        <div className = {"track-result-card"} id = {"tracks"+props.resultInfo.id} onClick = {addTrack}>
+        <div className = {"track-result-card"} id = {"tracks"+props.resultInfo.id}>
             <div style = {{display: "flex", alignItems:"center"}}>
                 <img src = {returnImages()} style = {{width:"50px", height:"50px", marginRight: "1rem"}}/>
                 <div>

--- a/front/src/components/SearchBox.tsx
+++ b/front/src/components/SearchBox.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ArtistResultCard, artistResponse } from "./ArtistResultCard";
 import { TrackResultCard, trackResponse } from "./TrackResultCard";
 import { RiSearchLine } from "../../node_modules/react-icons/ri";
+import { GenreResultCard } from "./GenreResultCard";
 
 interface prop {
   seedType: string; // either artist or track
@@ -11,6 +12,10 @@ interface prop {
   setSelectedSeeds: React.Dispatch<React.SetStateAction<string[][]>>;
 }
 
+export interface genreResponse {
+  type: string
+  data: string
+}
 /**
  * The component responsible for creading search boxes and dropdown 
  * search options
@@ -19,18 +24,57 @@ interface prop {
  */
 export function SearchBox(props: prop) {
   const [search, setSearch] = useState<string>("");
+  const [genres, setGenres] = useState<string[]>([])
 
   const [searchResults, setSearchResults] = useState<
-    artistResponse[] | trackResponse[]
+    artistResponse[] | trackResponse[] | genreResponse[]
   >([]);
 
   /**
    * Responsible for fetching song or track data
    */
   async function fetchData() {
+    if (props.seedType == "artists" || props.seedType == "tracks") {
+      try {
+        const url = `http://localhost:3000/search?${props.seedType}=${encodeURIComponent(search)}`;
+        console.log(url);
+        const response = await fetch(url);
+  
+        if (!response.ok) {
+          throw new Error("Failed to fetch data");
+        }
+  
+        const data = await response.json();
+  
+        if ("data" in data) {
+          setSearchResults(data.data);
+        } else {
+          console.error("No data within the response?? shouldn't happen.");
+        }
+      } catch (error) {
+        console.error("Error during fetch:");
+      }
+    } else {
+
+      let res : genreResponse[] = [];
+      for (let i = 0; i < genres.length; i ++) {
+        if (genres[i].startsWith(search)) {
+          res = [...res, {type: "genre", data: genres[i]}]
+          
+        }
+        if (res.length == 5) {
+          break
+        }
+      }
+
+      setSearchResults(res)
+    }
+
+  }
+  
+  async function fetchGenres() {
     try {
-      const url = `http://localhost:3000/search?${props.seedType}=${encodeURIComponent(search)}`;
-      console.log(url);
+      const url = `http://localhost:3000/get_genres`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -40,9 +84,9 @@ export function SearchBox(props: prop) {
       const data = await response.json();
 
       if ("data" in data) {
-        setSearchResults(data.data);
+        setGenres(data.data.genres);
       } else {
-        console.error("No data within the response?? shouldn't happen.");
+        console.error("Genres could not be fetched??");
       }
     } catch (error) {
       console.error("Error during fetch:");
@@ -53,14 +97,19 @@ export function SearchBox(props: prop) {
    * re-searches everytime the textbox is udpated.
    */
   useEffect(() => {
-    console.log(search);
     if (search != "") {
       fetchData();
     } else {
       setSearchResults([]);
     }
-    console.log(searchResults);
   }, [search]);
+
+  useEffect(() => {
+    console.log(props.seedType)
+    if (props.seedType === "genres") {
+      fetchGenres()
+    }
+  }, [])
 
   // updater function
     function handleChange(event: React.ChangeEvent<HTMLInputElement>)  {
@@ -77,7 +126,8 @@ export function SearchBox(props: prop) {
         onChange={handleChange}
       ></input>
 
-      {searchResults.map((res: artistResponse | trackResponse) => {
+      {searchResults.map((res: artistResponse | trackResponse | genreResponse) => {
+        console.log(res)
         if ("type" in res) {
           if (res.type == "artist") {
             res = res as artistResponse;
@@ -99,8 +149,17 @@ export function SearchBox(props: prop) {
                 seedMap={props.seedMap}
               ></TrackResultCard>
             );
+          } else if (res.type == "genre") {
+            res = res as genreResponse;
+            return (<GenreResultCard
+              selectedSeeds={props.selectedSeeds}
+              setSelectedSeeds={props.setSelectedSeeds}
+              resultInfo={res}
+              seedMap={props.seedMap}></GenreResultCard>
+              )
+            
           }
-        } else {
+        }else {
           console.error("could not find type in the response object.");
         }
       })}

--- a/front/src/components/SelectedItems.tsx
+++ b/front/src/components/SelectedItems.tsx
@@ -20,30 +20,6 @@ interface prop {
  * @returns component 
  */
 export function SelectedItems( props: prop ) {
-//   const [queryResult, setQueryResult] = useState<queryResponse | null>(null);
-
-//   useEffect(() => {
-//     fetchCall(props.category, props.id);
-//     console.log(queryResult)
-//   }, []); // Empty dependency array to run only once when the component mounts
-
-
-//   async function fetchCall(category: String, id: String) {
-//     try {
-//       const url = `http://localhost:3000/search_id?category=${category}&id=${id}`;
-//       const response = await fetch(url).then(res => res.json());
-
-//       console.log(response)
-
-//       if (response.status === "success") {
-//         setQueryResult(response);
-//       } else {
-//         console.error("Faulty request");
-//       }
-//     } catch (error) {
-//       console.error("Error fetching data:", error);
-//     }
-//   }
 
   /**
    * unselects something (removes a track or a song) from the shared state objects.

--- a/front/src/css/App.css
+++ b/front/src/css/App.css
@@ -242,3 +242,5 @@ nav button {
   left: 0em;
   top: calc(0em - 1.5px);
 }
+
+

--- a/front/src/css/SelectPage.css
+++ b/front/src/css/SelectPage.css
@@ -295,3 +295,29 @@
   width: 1.5em;
   opacity: 0.5;
 }
+
+.enter-time input[type="number"] {
+  -webkit-appearance: none; /* Override default look */
+  appearance: none;
+
+  background-color: transparent;
+
+  border-bottom: white 1px solid;
+  border-top:transparent;
+  border-left:transparent;
+  border-right:transparent;
+
+
+  width: 3em;
+  height:2em;
+  margin-left: 1em;
+
+  font-size: 5em;
+  
+  text-align: right;
+  /* text-align: bottom; */
+  align-items: center;
+}
+.enter-time input[type="number"]:active {
+  outline: transparent
+}

--- a/front/src/endpoints/InitialAuth.tsx
+++ b/front/src/endpoints/InitialAuth.tsx
@@ -1,30 +1,36 @@
-import { useNavigate } from "react-router-dom";
-// import { sharedProps } from '../App';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export function InitialAuth() {
   const nav = useNavigate();
-  let error: string = "";
+  const [authUrl, setAuthUrl] = useState('');
+  const[error, setError] = useState<string>('')
 
-  async function auth() {
-    const authEndpoint: string = "http://localhost:3000/client_auth";
+  useEffect(() => {
+    async function fetchAuthUrl(){
+      const authEndpoint: string = 'http://localhost:3000/client_auth';
 
-    const response = await fetch(authEndpoint).then((res) => res.json());
+      const response = await fetch(authEndpoint).then((res) => res.json());
 
-    console.log(response);
+      console.log(response);
 
-    if (response.status === "success") {
-      nav("/feats");
-    } else {
-      error =
-        "Could not proceed with user flow; please refresh or contact admin.";
-    }
-  }
+      if (response.status === 'success') {
+        // nav("/feats");
+        setAuthUrl('http://localhost:3000/auth');
+      } else {
+        setError('Could not proceed with the user flow; please refresh or contact admin.')
+        setAuthUrl('#');
+      }
+    };
+
+    fetchAuthUrl();
+  }, []); // Empty dependency array ensures that the effect runs only once when the component mounts
 
   return (
     <div>
-      <button className="get-started-button" onClick={auth}>
-        Get Started
-      </button>
+      <a href={authUrl}>
+        <button className="get-started-button">Authenticate</button>
+      </a>
       <p>{error}</p>
     </div>
   );

--- a/front/src/endpoints/InitialAuth.tsx
+++ b/front/src/endpoints/InitialAuth.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 export function InitialAuth() {
-  const nav = useNavigate();
   const [authUrl, setAuthUrl] = useState('');
   const[error, setError] = useState<string>('')
 
@@ -15,7 +13,6 @@ export function InitialAuth() {
       console.log(response);
 
       if (response.status === 'success') {
-        // nav("/feats");
         setAuthUrl('http://localhost:3000/auth');
       } else {
         setError('Could not proceed with the user flow; please refresh or contact admin.')

--- a/front/src/endpoints/UserAuth.tsx
+++ b/front/src/endpoints/UserAuth.tsx
@@ -11,7 +11,7 @@ export function UserAuth() {
     return (
         <a href = {authHandle()}>
             <button onClick={authHandle}>
-                Get Started
+                Add to Library
             </button>
         </a>
     )

--- a/front/src/pages/DurationsPage.tsx
+++ b/front/src/pages/DurationsPage.tsx
@@ -1,10 +1,20 @@
 import { useNavigate } from "react-router-dom";
 import "../css/App.css";
 import { useEffect, useState } from "react";
+import { trackResponse } from "../components/TrackResultCard";
 
 interface sharedProps {
     seedMap: Map<String, String[]>
     featsMap: Map<String, Number>
+
+    returnedTracks: trackResponse[]
+    setReturnedTracks: React.Dispatch<React.SetStateAction<trackResponse[]>>;
+
+    totalTime: number
+    setTotalTime: React.Dispatch<React.SetStateAction<number>>;
+
+    noSongs: number
+    setNoSongs: React.Dispatch<React.SetStateAction<number>>;
 }
 
 /**
@@ -58,9 +68,17 @@ export function DurationPage(props: sharedProps) {
       let duration = `${mode}=${totalDuration}`
       const finalQuery = await fetch(baseurl + url + duration).then(res => res.json())
 
+      if (finalQuery.status == "success") {
+        props.setReturnedTracks(finalQuery.data.tracks)
+        props.setNoSongs(finalQuery.data.no_songs)
+        props.setTotalTime(finalQuery.data.total_ms)
+        nav('/results')
+
+      } else {
+        console.error("error ocurred in fetch; could not perform query")
+      }
       console.log(finalQuery)
       console.log(baseurl + url + duration)
-    // nav('/results')
   }
   return (
     <>

--- a/front/src/pages/DurationsPage.tsx
+++ b/front/src/pages/DurationsPage.tsx
@@ -166,18 +166,21 @@ function NumberSelector(props: prop) {
     function renderComp() {
         if (props.mode == "duration") {
             return (
-                <div>
-                    <input type = "number" onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                <div className = "enter-time">
+                    <input type = "number" className = "hour-selector" onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                         return changeVal(event, setHour)}} max = "4" value = {hour}></input>
-                    <input type = "number" onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        <label>hr</label>
+                    <input type = "number" className = "minute-selector" onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                         return changeVal(event, setVal)}} max = "59" value = {val}></input>  
+                        <label>min</label>
                 </div>
             )
         } else if (props.mode == "number") {
             return (   
-                <div>
-                    <input type = "number" onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                <div className = "enter-time">
+                    <input className = "minute-selector" type = "number" onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                         return changeVal(event, setVal)}} max = "100" value = {val}></input>  
+                        <label>no. songs</label>
                 </div>)
         } else {
             console.error("mode not duration or number")

--- a/front/src/pages/HomePage.tsx
+++ b/front/src/pages/HomePage.tsx
@@ -2,8 +2,21 @@ import "../css/App.css";
 import { useState, useEffect } from "react";
 import MusicGraph from "../components/MusicGraph";
 import { InitialAuth } from "../endpoints/InitialAuth";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
-export function HomePage() {
+interface prop {
+  authToken: string
+  setAuthToken: React.Dispatch<React.SetStateAction<string>>
+}
+export function HomePage(props: prop) {
+
+  // checking for the presence of an authentication token
+  let [searchParams] = useSearchParams();
+  const authToken = searchParams.get("success")
+
+  const navigate = useNavigate()
+
+  const [nav, setNav] = useState<JSX.Element>()
   const [word, setWord] = useState<string>("dancing");
   const [barData, setBarData] = useState<string[][]>([
     ["2em", "", ""],
@@ -126,6 +139,38 @@ export function HomePage() {
     }, 3000);
   }, [step]);
 
+ 
+
+  useEffect(() => {
+    // console.log(props.returnedTracks)
+    if (authToken == null) {
+      setNav(
+        <InitialAuth></InitialAuth>
+      )
+    } else {
+      // we set the authentication token in the beginning and carry it throughout
+      // the user experience.
+      console.log("do something with the token ")
+
+
+      props.setAuthToken(authToken)
+
+      setNav(
+        <div>
+            <button
+            className="get-started-button"
+            id="continue-button"
+            onClick={() => navigate("/feats")}>
+              Continue
+              <p style = {{fontSize: "4px"}}><i>authenticated</i></p>
+          </button>
+        </div>           
+)
+
+    }
+  }, [])
+
+
   return (
     <>
       <body>
@@ -134,7 +179,7 @@ export function HomePage() {
             <a id="logo" href="/">
               <h2>Amplify</h2>
             </a>
-            <InitialAuth />
+            {nav}
           </nav>
           <div className="content">
             <MusicGraph barData={barData} />

--- a/front/src/pages/HomePage.tsx
+++ b/front/src/pages/HomePage.tsx
@@ -165,10 +165,7 @@ export function HomePage(props: prop) {
               <p style = {{fontSize: "4px"}}><i>authenticated</i></p>
           </button>
         </div>           
-)
-
-    }
-  }, [])
+    )}}, [])
 
 
   return (

--- a/front/src/pages/ResultsPage.tsx
+++ b/front/src/pages/ResultsPage.tsx
@@ -1,20 +1,57 @@
-import { UserAuth } from "../endpoints/UserAuth";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useEffect } from "react";
+import { trackResponse } from "../components/TrackResultCard";
+import { RecommendedTrackCard } from "../components/RecommendedTrackCard";
 
-export function ResultsPage() {
+
+interface sharedProps {
+  returnedTracks: trackResponse[]
+  setReturnedTracks: React.Dispatch<React.SetStateAction<trackResponse[]>>;
+
+  totalTime: number
+  setTotalTime: React.Dispatch<React.SetStateAction<number>>;
+
+  noSongs: number
+  setNoSongs: React.Dispatch<React.SetStateAction<number>>;
+
+  authToken: string
+}
+
+export function ResultsPage(props: sharedProps) {
 
     let [searchParams] = useSearchParams();
 
-    useEffect(() => {
-      const authToken = searchParams.get("success")
-      if (authToken == null) {
-        console.log("don't do anything")
-      } else {
-        console.log("do something with the token ")
-      }
-    })
+    async function createPlaylist(authToken: string) {
+      let url = "http://localhost:3000/generate_playlist?"
+      url += `${'userToken'}=${authToken}&`
+      url += `songs=${props.returnedTracks.map(track => track.uri).join(',')}`
+      console.log(url)
+      let genPlaylist = await fetch(url).then(res => res.json())
 
+
+      if (genPlaylist.status === "success") {
+        console.log('successfully addded to library')
+      } else {
+        console.error('error occurred in adding to library')
+      }
+
+
+    }
+
+    useEffect(() => {
+      const continueButton = document.getElementById("continue-button");
+      if (props.authToken === "") {
+        if (continueButton) {
+          continueButton.classList.add("toggle");
+        }
+      } else {
+        if (continueButton) {
+          continueButton.classList.remove("toggle");
+        }
+      }
+    }, []);
+
+    // aa
     return (
       <>
         <body>
@@ -23,10 +60,18 @@ export function ResultsPage() {
               <a href = "/">
                 <h2>Amplify</h2>
               </a>
-              <UserAuth></UserAuth>
+              <button className="get-started-button" id="continue-button" onClick={() => createPlaylist(props.authToken)}>
+                Add to Library
+              </button>
             </nav>
+
+            <div>
+              {props.returnedTracks.map(track =>   
+             <RecommendedTrackCard resultInfo = {track}></RecommendedTrackCard>)}
+            </div>
           </main>
         </body>
       </>
     );
   }
+

--- a/front/src/pages/ResultsPage.tsx
+++ b/front/src/pages/ResultsPage.tsx
@@ -1,4 +1,3 @@
-import { useSearchParams } from "react-router-dom";
 import { useEffect } from "react";
 import { trackResponse } from "../components/TrackResultCard";
 import { RecommendedTrackCard } from "../components/RecommendedTrackCard";
@@ -19,8 +18,6 @@ interface sharedProps {
 
 export function ResultsPage(props: sharedProps) {
 
-    let [searchParams] = useSearchParams();
-
     async function createPlaylist(authToken: string) {
       let url = "http://localhost:3000/generate_playlist?"
       url += `${'userToken'}=${authToken}&`
@@ -28,14 +25,11 @@ export function ResultsPage(props: sharedProps) {
       console.log(url)
       let genPlaylist = await fetch(url).then(res => res.json())
 
-
       if (genPlaylist.status === "success") {
         console.log('successfully addded to library')
       } else {
         console.error('error occurred in adding to library')
       }
-
-
     }
 
     useEffect(() => {

--- a/front/src/pages/SelectSeedsPage.tsx
+++ b/front/src/pages/SelectSeedsPage.tsx
@@ -11,7 +11,7 @@ interface sharedProps {
 }
 
 export function SelectSeedsPage(props: sharedProps) {
-  //selected seeds is an array of arrays where each inner array has the following elements:
+  // selected seeds is an array of arrays where each inner array has the following elements:
   // [0] = id (of the track or artist)
   // [1] = category (indicating track or artit)
   // [2] = name


### PR DESCRIPTION
This branch really just focused on making sure that we could (1) hit the get_recommendations endpoint from the front end and (2) that we could pass the results from this get_recommendations endpoint into the generate playlist endpoint. This allows us to create and add a playlist to a user's library. Overall, everything seems to be working, but further ux improvements can be made. Specifically, the home page will reload given upon authentication (the way that spotify auth works) but that will retrigger all of the animations again, which isn't... ideal. 